### PR TITLE
Jazzy

### DIFF
--- a/include/stage_ros2/stage_node.hpp
+++ b/include/stage_ros2/stage_node.hpp
@@ -114,6 +114,7 @@ private:
     std::string topic_name_space_;
     std::string frame_name_space_;
     std::string topic_name_cmd_;
+    std::string topic_name_cmd_unstamped_;
 
     std::string topic_name_tf_;
     std::string topic_name_tf_static_;
@@ -134,6 +135,7 @@ private:
     const std::string &name_space() const;
     void init(bool use_topic_prefixes, bool use_one_tf_tree);
     void callback_cmd(const geometry_msgs::msg::TwistStamped::SharedPtr msg);
+    void callback_cmd_unstamped(const geometry_msgs::msg::Twist::SharedPtr msg);
     void publish_msg();
     void publish_tf();
     void check_watchdog_timeout();
@@ -148,9 +150,10 @@ private:
     std::vector<std::shared_ptr<Camera>> cameras_; // multiple cameras per position
 
     // ros publishers
-    rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_odom_;            // one odom
-    rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_ground_truth_;    // one ground truth
-    rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_cmd_; // one cmd_vel subscriber
+    rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_odom_;               // one odom
+    rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_ground_truth_;       // one ground truth
+    rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_cmd_;    // one cmd_vel subscriber
+    rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr sub_cmd_unstamped_; // one cmd_vel subscriber
 
     std::shared_ptr<stage_ros2::StaticTransformBroadcaster> tf_static_broadcaster_;
     std::shared_ptr<stage_ros2::TransformBroadcaster> tf_broadcaster_;

--- a/include/stage_ros2/stage_node.hpp
+++ b/include/stage_ros2/stage_node.hpp
@@ -13,7 +13,7 @@
 // roscpp
 #include <rclcpp/rclcpp.hpp>
 #include <std_srvs/srv/empty.hpp>
-#include <geometry_msgs/msg/twist.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/image_encodings.hpp>
@@ -30,8 +30,6 @@
 
 #include "stage_ros2/visibility.h"
 
-
-
 // Our node
 class StageNode : public rclcpp::Node
 {
@@ -45,12 +43,12 @@ private:
   // a structure representing a robot inthe simulator
   class Vehicle
   {
-public:
+  public:
     class Ranger
     {
       bool initialized_;
       size_t id_;
-      Stg::ModelRanger * model;
+      Stg::ModelRanger *model;
       std::shared_ptr<Vehicle> vehicle;
       std::string topic_name;
       std::string frame_base;
@@ -61,9 +59,9 @@ public:
       bool prepare_msg();
       bool prepare_tf();
 
-public:
+    public:
       Ranger(
-        unsigned int id, Stg::ModelRanger * m, std::shared_ptr<Vehicle> & vehicle);
+          unsigned int id, Stg::ModelRanger *m, std::shared_ptr<Vehicle> &vehicle);
       void init(bool add_id_to_topic);
       unsigned int id() const;
       void publish_msg();
@@ -73,14 +71,14 @@ public:
     {
       bool initialized_;
       size_t id_;
-      Stg::ModelCamera * model;
+      Stg::ModelCamera *model;
       std::shared_ptr<Vehicle> vehicle;
       geometry_msgs::msg::TransformStamped::SharedPtr transform;
-      rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr pub_image;             // multiple images
+      rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr pub_image; // multiple images
       sensor_msgs::msg::Image::SharedPtr msg_image;
-      rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr pub_depth;             // multiple depths
+      rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr pub_depth; // multiple depths
       sensor_msgs::msg::Image::SharedPtr msg_depth;
-      rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr pub_camera;       // multiple cameras
+      rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr pub_camera; // multiple cameras
       sensor_msgs::msg::CameraInfo::SharedPtr msg_camera;
       bool prepare_msg();
       bool prepare_msg_image();
@@ -88,9 +86,9 @@ public:
       bool prepare_msg_camera();
       bool prepare_tf();
 
-public:
+    public:
       Camera(
-        unsigned int id, Stg::ModelCamera * m, std::shared_ptr<Vehicle> & vehicle);
+          unsigned int id, Stg::ModelCamera *m, std::shared_ptr<Vehicle> &vehicle);
       void init(bool add_id_to_topic);
       unsigned int id() const;
       void publish_msg();
@@ -101,15 +99,15 @@ public:
       std::string frame_id;
     };
 
-private:
+  private:
     bool initialized_;
     size_t id_;
     Stg::Pose initial_pose_;
-    std::string name_;     /// used for the ros publisher
-    StageNode * node_;
-    Stg::World * world_;
+    std::string name_; /// used for the ros publisher
+    StageNode *node_;
+    Stg::World *world_;
     rclcpp::Time time_last_cmd_received_;
-    rclcpp::Time timeout_cmd_;        /// if no command is received befor the vehicle is stopped
+    rclcpp::Time timeout_cmd_; /// if no command is received befor the vehicle is stopped
     // Last time we saved global position (for velocity calculation).
     rclcpp::Time time_last_pose_update_;
 
@@ -127,31 +125,32 @@ private:
     nav_msgs::msg::Odometry msg_odom_;
     std::shared_ptr<Stg::Pose> global_pose_;
 
-public:
-    Vehicle(size_t id, const Stg::Pose & pose, const std::string & name, StageNode * node);
+  public:
+    Vehicle(size_t id, const Stg::Pose &pose, const std::string &name, StageNode *node);
 
     void soft_reset();
     size_t id() const;
-    const std::string & name() const;
-    const std::string & name_space() const;
+    const std::string &name() const;
+    const std::string &name_space() const;
     void init(bool use_topic_prefixes, bool use_one_tf_tree);
-    void callback_cmd(const geometry_msgs::msg::Twist::SharedPtr msg);
+    void callback_cmd(const geometry_msgs::msg::TwistStamped::SharedPtr msg);
     void publish_msg();
     void publish_tf();
     void check_watchdog_timeout();
-    StageNode *node(){
+    StageNode *node()
+    {
       return node_;
     }
 
     // stage related models
-    Stg::ModelPosition * positionmodel;               // one position
-    std::vector<std::shared_ptr<Ranger>> rangers_;     // multiple rangers per position
-    std::vector<std::shared_ptr<Camera>> cameras_;      // multiple cameras per position
+    Stg::ModelPosition *positionmodel;             // one position
+    std::vector<std::shared_ptr<Ranger>> rangers_; // multiple rangers per position
+    std::vector<std::shared_ptr<Camera>> cameras_; // multiple cameras per position
 
     // ros publishers
-    rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_odom_;             // one odom
-    rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_ground_truth_;     // one ground truth
-    rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr sub_cmd_;     // one cmd_vel subscriber
+    rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_odom_;            // one odom
+    rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_ground_truth_;    // one ground truth
+    rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_cmd_; // one cmd_vel subscriber
 
     std::shared_ptr<stage_ros2::StaticTransformBroadcaster> tf_static_broadcaster_;
     std::shared_ptr<stage_ros2::TransformBroadcaster> tf_broadcaster_;
@@ -160,17 +159,16 @@ public:
   /// vector to hold the simulated vehicles with ros interfaces
   std::vector<std::shared_ptr<Vehicle>> vehicles_;
 
-
-  bool isDepthCanonical_;                  /// ROS parameter
-  bool enforce_prefixes_;                  /// ROS parameter
-  bool one_tf_tree_;                       /// ROS parameter
-  bool enable_gui_;                        /// ROS parameter
-  bool publish_ground_truth_;              /// ROS parameter
-  bool use_static_transformations_;        /// ROS parameter
-  std::string world_file_;                 /// ROS parameter
-  std::string frame_id_odom_name_;         /// ROS parameter
-  std::string frame_id_world_name_;        /// ROS parameter
-  std::string frame_id_base_link_name_;    /// ROS parameter
+  bool isDepthCanonical_;               /// ROS parameter
+  bool enforce_prefixes_;               /// ROS parameter
+  bool one_tf_tree_;                    /// ROS parameter
+  bool enable_gui_;                     /// ROS parameter
+  bool publish_ground_truth_;           /// ROS parameter
+  bool use_static_transformations_;     /// ROS parameter
+  std::string world_file_;              /// ROS parameter
+  std::string frame_id_odom_name_;      /// ROS parameter
+  std::string frame_id_world_name_;     /// ROS parameter
+  std::string frame_id_base_link_name_; /// ROS parameter
 
   // TF broadcaster to publish the robot odom
   std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_stage_;
@@ -182,15 +180,15 @@ public:
   rclcpp::Publisher<rosgraph_msgs::msg::Clock>::SharedPtr clock_pub_;
 
   /// called only ones to init the models and to crate for each model a link to ROS
-  static int callback_init_stage_model(Stg::Model * mod, StageNode * node);
+  static int callback_init_stage_model(Stg::Model *mod, StageNode *node);
 
   /// called on every simulation interation
-  static int callback_update_stage_world(Stg::World * world, StageNode * node);
+  static int callback_update_stage_world(Stg::World *world, StageNode *node);
 
 public:
   ~StageNode();
   // Constructor
-  void init(int argc, char ** argv);
+  void init(int argc, char **argv);
 
   // declares ros parameters
   void declare_parameters();
@@ -215,10 +213,10 @@ public:
 
   // Service callback for soft reset
   bool cb_reset_srv(const std_srvs::srv::Empty::Request::SharedPtr,
-    std_srvs::srv::Empty::Response::SharedPtr);
+                    std_srvs::srv::Empty::Response::SharedPtr);
 
   // The main simulator object
-  Stg::World * world;
+  Stg::World *world;
 
   rclcpp::Duration base_watchdog_timeout_;
 
@@ -227,11 +225,10 @@ public:
 
 private:
   static geometry_msgs::msg::TransformStamped create_transform_stamped(
-    const tf2::Transform & in,
-    const rclcpp::Time & timestamp, const std::string & frame_id,
-    const std::string & child_frame_id);
+      const tf2::Transform &in,
+      const rclcpp::Time &timestamp, const std::string &frame_id,
+      const std::string &child_frame_id);
   static geometry_msgs::msg::Quaternion createQuaternionMsgFromYaw(double yaw);
-
 };
 
 #endif // STAGE_ROS2_PKG__STAGE_ROS_HPP_

--- a/package.xml
+++ b/package.xml
@@ -10,23 +10,15 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
 
-  <build_depend>rclcpp</build_depend>
-  <build_depend>rclcpp_components</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>nav_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>tf2</build_depend>
-
-
-  <exec_depend>rclcpp</exec_depend>
-  <exec_depend>rclcpp_components</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>nav_msgs</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>tf2</exec_depend>
-  <exec_depend>std_srvs</exec_depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>sensor_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>std_srvs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -12,22 +12,20 @@
 
   <build_depend>rclcpp</build_depend>
   <build_depend>rclcpp_components</build_depend>
-  <build_depend>Stage</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>tf</build_depend>
+  <build_depend>tf2</build_depend>
 
 
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclcpp_components</exec_depend>
-  <exec_depend>Stage</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>tf</exec_depend>
+  <exec_depend>tf2</exec_depend>
   <exec_depend>std_srvs</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-
+  <depend>Stage</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -53,8 +53,10 @@ void StageNode::Vehicle::init(bool use_topic_prefixes, bool use_one_tf_tree)
   {
     frame_name_space_ = name() + "/";
     topic_name_tf_ = std::string("/") + TOPIC_TF;
-    topic_name_tf_static_ =  std::string("/") + TOPIC_TF_STATIC;
-  } else {
+    topic_name_tf_static_ = std::string("/") + TOPIC_TF_STATIC;
+  }
+  else
+  {
     topic_name_tf_ = topic_name_space_ + TOPIC_TF;
     topic_name_tf_static_ = topic_name_space_ + TOPIC_TF_STATIC;
   }
@@ -74,7 +76,7 @@ void StageNode::Vehicle::init(bool use_topic_prefixes, bool use_one_tf_tree)
   pub_ground_truth_ =
       node_->create_publisher<nav_msgs::msg::Odometry>(topic_name_ground_truth_, 10);
   sub_cmd_ =
-      node_->create_subscription<geometry_msgs::msg::Twist>(
+      node_->create_subscription<geometry_msgs::msg::TwistStamped>(
           topic_name_cmd_, 10,
           std::bind(&StageNode::Vehicle::callback_cmd, this, _1));
 
@@ -190,13 +192,13 @@ void StageNode::Vehicle::check_watchdog_timeout()
     }
   }
 }
-void StageNode::Vehicle::callback_cmd(const geometry_msgs::msg::Twist::SharedPtr msg)
+void StageNode::Vehicle::callback_cmd(const geometry_msgs::msg::TwistStamped::SharedPtr msg)
 {
   std::scoped_lock lock(node_->msg_lock);
   this->positionmodel->SetSpeed(
-      msg->linear.x,
-      msg->linear.y,
-      msg->angular.z);
+      msg->twist.linear.x,
+      msg->twist.linear.y,
+      msg->twist.angular.z);
   time_last_cmd_received_ = node_->sim_time_;
   timeout_cmd_ = time_last_cmd_received_ + node_->base_watchdog_timeout_;
 }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -45,18 +45,17 @@ void StageNode::Vehicle::init(bool use_topic_prefixes, bool use_one_tf_tree)
 
   topic_name_space_ = std::string();
   frame_name_space_ = std::string();
-  if (use_topic_prefixes == true)
-  {
-    topic_name_space_ = name() + "/";
-  }
+
   if (use_one_tf_tree)
   {
-    frame_name_space_ = name() + "/";
+    if (use_topic_prefixes)
+      frame_name_space_ = name() + "/";
     topic_name_tf_ = std::string("/") + TOPIC_TF;
     topic_name_tf_static_ = std::string("/") + TOPIC_TF_STATIC;
   }
   else
   {
+    frame_name_space_ = name() + "/";
     topic_name_tf_ = topic_name_space_ + TOPIC_TF;
     topic_name_tf_static_ = topic_name_space_ + TOPIC_TF_STATIC;
   }
@@ -68,6 +67,7 @@ void StageNode::Vehicle::init(bool use_topic_prefixes, bool use_one_tf_tree)
   topic_name_odom_ = topic_name_space_ + TOPIC_ODOM;
   topic_name_ground_truth_ = topic_name_space_ + TOPIC_GROUND_TRUTH;
   topic_name_cmd_ = topic_name_space_ + TOPIC_CMD_VEL;
+  topic_name_cmd_unstamped_ = topic_name_space_ + TOPIC_CMD_VEL + "_unstamped";
 
   tf_static_broadcaster_ = std::make_shared<stage_ros2::StaticTransformBroadcaster>(node_, topic_name_tf_static_.c_str());
   tf_broadcaster_ = std::make_shared<stage_ros2::TransformBroadcaster>(node_, topic_name_tf_.c_str());
@@ -79,6 +79,10 @@ void StageNode::Vehicle::init(bool use_topic_prefixes, bool use_one_tf_tree)
       node_->create_subscription<geometry_msgs::msg::TwistStamped>(
           topic_name_cmd_, 10,
           std::bind(&StageNode::Vehicle::callback_cmd, this, _1));
+  sub_cmd_unstamped_ =
+      node_->create_subscription<geometry_msgs::msg::Twist>(
+          topic_name_cmd_unstamped_, 10,
+          std::bind(&StageNode::Vehicle::callback_cmd_unstamped, this, _1));
 
   positionmodel->Subscribe();
 
@@ -199,6 +203,16 @@ void StageNode::Vehicle::callback_cmd(const geometry_msgs::msg::TwistStamped::Sh
       msg->twist.linear.x,
       msg->twist.linear.y,
       msg->twist.angular.z);
+  time_last_cmd_received_ = node_->sim_time_;
+  timeout_cmd_ = time_last_cmd_received_ + node_->base_watchdog_timeout_;
+}
+void StageNode::Vehicle::callback_cmd_unstamped(const geometry_msgs::msg::Twist::SharedPtr msg)
+{
+  std::scoped_lock lock(node_->msg_lock);
+  this->positionmodel->SetSpeed(
+      msg->linear.x,
+      msg->linear.y,
+      msg->angular.z);
   time_last_cmd_received_ = node_->sim_time_;
   timeout_cmd_ = time_last_cmd_received_ + node_->base_watchdog_timeout_;
 }

--- a/world/cave.world
+++ b/world/cave.world
@@ -72,5 +72,5 @@ pioneer2dx_with_laser
   # can refer to the robot by this name
   name "robot_0"
   color "red" 
-  pose [ -7 -7 0 45 ] 
+  pose [ -7 -7 0 0 ] 
 )

--- a/world/straden.world
+++ b/world/straden.world
@@ -68,4 +68,8 @@ pioneer2dx_with_laser
   name "robot_0"
   color "red" 
   pose [ 0 -32 0 180 ] 
+
+  localization "odom"           # Change to "gps" to have impossibly perfect, global odometry 
+  odom_error [ 0.0 0.0 0.0 0.0 ]  # Odometry error or slip in X, Y and Theta  (Uniform random distribution)   
+ 
 )


### PR DESCRIPTION
1. Make TwistStamped the default message subscribed to via cmd_vel. In Jazzy most packages use this instead of the unstamped version. 
2. Fix package.xml so that the dependencies are consistent with CMakeLists.txt
This should result in rosdep not failing. 